### PR TITLE
Delete unnecessary "name" key in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,5 @@
 {
   "id": "pf2e-subsystems",
-  "name": "pf2e-subsystems",
   "title": "PF2e Subsystems",
   "description": "A module to handle the various subsystems of play in the PF2e system",
   "version": "0.8.5",


### PR DESCRIPTION
This fixes the console warning in FoundryV13 setup page.
<img width="836" height="51" alt="image" src="https://github.com/user-attachments/assets/0ef560bf-4a5b-4298-a588-abc9199f1cf4" />
